### PR TITLE
fix/user 32 - 프로필 이미지 관련 API response 속 id의 자료형 변경

### DIFF
--- a/src/main/java/org/slams/server/user/dto/response/UserWithoutEmailDto.java
+++ b/src/main/java/org/slams/server/user/dto/response/UserWithoutEmailDto.java
@@ -16,7 +16,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserWithoutEmailDto {
 
-	private Long id;
+	private String id;
 	private String nickname;
 	private String profileImage;
 	private String description;
@@ -26,7 +26,7 @@ public class UserWithoutEmailDto {
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 
-	private UserWithoutEmailDto(Long id, String nickname, String profileImage, String description,
+	private UserWithoutEmailDto(String id, String nickname, String profileImage, String description,
 								Role role, Proficiency proficiency, List<Position> positions,
 								LocalDateTime createdAt, LocalDateTime updatedAt) {
 		this.id = id;
@@ -41,7 +41,7 @@ public class UserWithoutEmailDto {
 	}
 
 	public static UserWithoutEmailDto toDto(User user){
-		return new UserWithoutEmailDto(user.getId(), user.getNickname(), user.getProfileImage(), user.getDescription(),
+		return new UserWithoutEmailDto(user.getId().toString(), user.getNickname(), user.getProfileImage(), user.getDescription(),
 			user.getRole(), user.getProficiency(), user.getPositions(),
 			user.getCreatedAt(), user.getUpdateAt());
 	}

--- a/src/test/java/org/slams/server/user/controller/UserControllerTest.java
+++ b/src/test/java/org/slams/server/user/controller/UserControllerTest.java
@@ -448,7 +448,7 @@ class UserControllerTest {
 				preprocessResponse(prettyPrint()),
 				responseFields(
 					fieldWithPath("user").type(JsonFieldType.OBJECT).description("사용자"),
-					fieldWithPath("user.id").type(JsonFieldType.NUMBER).description("사용자 구별키"),
+					fieldWithPath("user.id").type(JsonFieldType.STRING).description("사용자 구별키"),
 					fieldWithPath("user.nickname").type(JsonFieldType.STRING).description("사용자 닉네임"),
 					fieldWithPath("user.description").type(JsonFieldType.STRING).description("사용자 한줄 소개"),
 					fieldWithPath("user.profileImage").type(JsonFieldType.NULL).description("사용자 프로필 이미지"),


### PR DESCRIPTION
지난번 api 리팩토링 이후 머지했을 때 발견하지 못한 오류(id의 자료형 Long -> String 변경)를 수정했습니다.
간단한 오류라 곧바로 머지 진행하겠습니다.

close #32 