### PR TITLE
fix/user 40 - 존재하지 않는 유저페이지에 접근 시 구체적인 에러메세지 생성

### DIFF
--- a/src/main/java/org/slams/server/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/slams/server/common/error/GlobalExceptionHandler.java
@@ -66,7 +66,7 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(EntityNotFoundException.class)
 	protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException e) {
 		log.error("handleEntityNotFoundException", e);
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.ENTITY_NOT_FOUND);
+		ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode());
 
 		return ResponseEntity.badRequest().body(errorResponse);
 	}
@@ -75,7 +75,7 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(InvalidValueException.class)
 	protected ResponseEntity<ErrorResponse> handleInvalidValueException(InvalidValueException e) {
 		log.error("handleInvalidValueException", e);
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+		ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode());
 
 		return ResponseEntity.badRequest().body(errorResponse);
 	}

--- a/src/main/java/org/slams/server/user/controller/UserController.java
+++ b/src/main/java/org/slams/server/user/controller/UserController.java
@@ -1,8 +1,11 @@
 package org.slams.server.user.controller;
 
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slams.server.common.error.ErrorResponse;
 import org.slams.server.user.dto.request.ExtraUserInfoRequest;
 import org.slams.server.user.dto.response.*;
 import org.slams.server.user.exception.InvalidTokenException;
@@ -56,8 +59,19 @@ public class UserController {
 		return ResponseEntity.ok(myProfileResponse);
 	}
 
+	@ApiResponses({
+		@ApiResponse(
+			code = 200
+			, message = "조회 성공"
+		),
+		@ApiResponse(
+			code = 400
+			, message = "존재하지 않는 유저에 접근"
+			, response = ErrorResponse.class
+		)
+	})
 	@GetMapping("/{userId}")
-	public ResponseEntity<UserProfileResponse> getUserInfo(HttpServletRequest request, @PathVariable Long userId){
+	public ResponseEntity<UserProfileResponse> getUserInfo(HttpServletRequest request, @PathVariable Long userId) {
 		String authorization = request.getHeader("Authorization");
 		String[] tokenString = authorization.split(" ");
 		if (!tokenString[0].equals("Bearer")) {


### PR DESCRIPTION
존재하지 않는 유저에 접근 시, ENTITY NOT FOUND라는 에러메세지를 ErrorResponse에 담아 전송하도록 수정했습니다.
그리고 이 부분이 Swagger에 명시될 수 있도록 controller단에 어노테이션 추가했습니다~

close #40 