### PR TITLE
feat/common 37 - swagger authorization button 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,13 +145,13 @@
         <!-- swagger 설정 -->
         <dependency>
             <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger2</artifactId>
-            <version>2.9.2</version>
+            <artifactId>springfox-boot-starter</artifactId>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.9.2</version>
+            <version>3.0.0</version>
         </dependency>
 
 

--- a/src/main/java/org/slams/server/common/config/SwaggerConfig.java
+++ b/src/main/java/org/slams/server/common/config/SwaggerConfig.java
@@ -6,9 +6,15 @@ import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.List;
 
 @Configuration
 @EnableSwagger2
@@ -16,22 +22,41 @@ public class SwaggerConfig {
 
 	@Bean
 	public Docket docket() {
-		return new Docket(DocumentationType.SWAGGER_2)
-			.useDefaultResponseMessages(false)
-			.apiInfo(apiInfo())
-			.select()
-			.apis(RequestHandlerSelectors.any())
-			.paths(PathSelectors.any())
-			.build();
+		return new Docket(DocumentationType.OAS_30)
+				.securityContexts(List.of(securityContext()))
+				.securitySchemes(List.of(apikey()))
+				.useDefaultResponseMessages(false)
+				.apiInfo(apiInfo())
+				.select()
+				.apis(RequestHandlerSelectors.any())
+				.paths(PathSelectors.any())
+				.build();
 	}
 
 	private ApiInfo apiInfo() {
 		return new ApiInfoBuilder()
-			.title("Slam Web Application Api")
-			.description("길거리 농구 매칭 앱")
-			.version("1.0.0")
-			.license("Copyright Slam")
-			.build();
+				.title("Slam Web Application Api")
+				.description("길거리 농구 매칭 앱")
+				.version("1.0.0")
+				.license("Copyright Slam")
+				.build();
+	}
+
+	private SecurityContext securityContext() {
+		return SecurityContext.builder()
+				.securityReferences(defaultAuth())
+				.build();
+	}
+
+	private List<SecurityReference> defaultAuth() {
+		AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+		AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+		authorizationScopes[0] = authorizationScope;
+		return List.of(new SecurityReference("Authorization", authorizationScopes));
+	}
+
+	private ApiKey apikey(){
+		return new ApiKey("Authorization", "Authorization", "header");
 	}
 
 }


### PR DESCRIPTION
- swagger 버전 3.0.0 으로 변경
- authorization button 추가 (목적: 테스트에 용이하기 때문에)


<결과>
<img width="915" alt="image" src="https://user-images.githubusercontent.com/88185304/172804854-e9d56d18-b2f1-4849-967d-abb800194027.png">

<사용방법> 
-  페이지 접근 : /swagger-ui/index.html    ex)http://127.0.0.1:8080/swagger-ui/index.html
- Authorization 버튼 클릭
- token 기입 : Bearer {token}