### PR TITLE
fix/court 75 - swagger 문서에 response값 표시 오류 해결

### DIFF
--- a/src/main/java/org/slams/server/reservation/dto/response/ReservationByCourtAndDateResponse.java
+++ b/src/main/java/org/slams/server/reservation/dto/response/ReservationByCourtAndDateResponse.java
@@ -1,11 +1,13 @@
 package org.slams.server.reservation.dto.response;
 
+import lombok.Getter;
 import org.slams.server.common.api.BaseResponse;
 import org.slams.server.reservation.entity.Reservation;
 import org.slams.server.user.dto.response.BriefUserInfoDto;
 
 import java.time.LocalDateTime;
 
+@Getter
 public class ReservationByCourtAndDateResponse extends BaseResponse {
 
 	private String id;
@@ -24,7 +26,7 @@ public class ReservationByCourtAndDateResponse extends BaseResponse {
 		this.user = user;
 	}
 
-	public static ReservationByCourtAndDateResponse of(Reservation reservation){
+	public static ReservationByCourtAndDateResponse of(Reservation reservation) {
 		return new ReservationByCourtAndDateResponse(reservation.getCreatedAt(), reservation.getUpdatedAt(),
 			reservation.getId().toString(), reservation.getStartTime(), reservation.getEndTime(), reservation.isHasBall(), BriefUserInfoDto.toDto(reservation.getUser()));
 	}


### PR DESCRIPTION
### 문제원인
response 클래스의 getter 메소드가 존재하지 않았음.

### 해결방법
response 클래스에 `@Getter` 추가

close #75 