### PR TITLE
fix/reservation 78 - proxy상태일 때 내부 상태값에 접근했을 때 발생하는 에러 해결

### DIFF
--- a/src/main/java/org/slams/server/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/slams/server/reservation/repository/ReservationRepository.java
@@ -26,7 +26,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             @Param("endLocalDateTime") LocalDateTime endLocalDateTime
            );
 
-    @Query("SELECT r FROM Reservation r WHERE r.user.id=:userId AND r.startTime>:localDateTime")
+    @Query("SELECT r FROM Reservation r JOIN FETCH r.court WHERE r.user.id=:userId AND r.startTime>:localDateTime")
     List<Reservation> findByUserFromStartTime(
         @Param("userId") Long userId,
         @Param("localDateTime") LocalDateTime localDateTime
@@ -66,7 +66,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     Optional<Reservation> findByCourtAndUser(Court court, User user);
 
-    @Query("SELECT r FROM Reservation r WHERE r.court.id = :courtId AND r.startTime < :endTime AND r.endTime > :startTime ORDER BY r.startTime")
+    @Query("SELECT r FROM Reservation r JOIN FETCH r.user WHERE r.court.id = :courtId AND r.startTime < :endTime AND r.endTime > :startTime ORDER BY r.startTime")
     List<Reservation> findByCourtIdAndDateBetweenOrderByStartTime(
         @Param("courtId") Long courtId,
         @Param("startTime") LocalDateTime startTime,

--- a/src/main/java/org/slams/server/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/slams/server/reservation/repository/ReservationRepository.java
@@ -26,11 +26,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             @Param("endLocalDateTime") LocalDateTime endLocalDateTime
            );
 
-    @Query("SELECT r FROM Reservation r JOIN FETCH r.court WHERE r.user.id=:userId AND r.startTime>:localDateTime")
-    List<Reservation> findByUserFromStartTime(
-        @Param("userId") Long userId,
-        @Param("localDateTime") LocalDateTime localDateTime
-    );
+	@Query("SELECT r FROM Reservation r JOIN FETCH r.court WHERE r.user.id=:userId AND r.startTime>:localDateTime")
+	List<Reservation> findByUserFromStartTime(
+		@Param("userId") Long userId,
+		@Param("localDateTime") LocalDateTime localDateTime
+	);
 
     @Query("SELECT r.user.id FROM Reservation r WHERE r.court.id=:courtId")
     List<Long> findBeakerIdByCourtId(
@@ -66,11 +66,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     Optional<Reservation> findByCourtAndUser(Court court, User user);
 
-    @Query("SELECT r FROM Reservation r JOIN FETCH r.user WHERE r.court.id = :courtId AND r.startTime < :endTime AND r.endTime > :startTime ORDER BY r.startTime")
-    List<Reservation> findByCourtIdAndDateBetweenOrderByStartTime(
-        @Param("courtId") Long courtId,
-        @Param("startTime") LocalDateTime startTime,
-        @Param("endTime") LocalDateTime endTime
-    );
+	@Query("SELECT r FROM Reservation r JOIN FETCH r.user WHERE r.court.id = :courtId AND r.startTime < :endTime AND r.endTime > :startTime ORDER BY r.startTime")
+	List<Reservation> findByCourtIdAndDateBetweenOrderByStartTime(
+		@Param("courtId") Long courtId,
+		@Param("startTime") LocalDateTime startTime,
+		@Param("endTime") LocalDateTime endTime
+	);
 
 }


### PR DESCRIPTION
## 에러 발생 이유
<img width="450" alt="스크린샷 2022-11-15 오전 1 25 48" src="https://user-images.githubusercontent.com/65434196/201712751-96423577-0c58-4d10-9f15-1924a78ef424.png">

Reservation 내 User, Court 모두 `FetchType.LAZY`로 되어있어 proxy로 조회해온다.
proxy상태일 때 각각 user의 이름, court의 이름을 가져와 500에러가 발생하였다.

## 해결 방법
fetch join

close #78 