### PR TITLE
fix/user 73 - user 이메일 수집 철회

### DIFF
--- a/src/main/java/org/slams/server/user/dto/response/DefaultUserInfoResponse.java
+++ b/src/main/java/org/slams/server/user/dto/response/DefaultUserInfoResponse.java
@@ -20,7 +20,6 @@ import java.util.List;
 public class DefaultUserInfoResponse {
 
 	private String id;
-	private String email;
 	private String nickname;
 	private String profileImage;
 	private String description;
@@ -31,12 +30,11 @@ public class DefaultUserInfoResponse {
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 
-	private DefaultUserInfoResponse(String id, String email, String nickname, String profileImage,
+	private DefaultUserInfoResponse(String id, String nickname, String profileImage,
 									String description, Role role, Proficiency proficiency, List<Position> positions,
 									List<NotificationResponse> notifications,
 									LocalDateTime createdAt, LocalDateTime updatedAt) {
 		this.id = id;
-		this.email = email;
 		this.nickname = nickname;
 		this.profileImage = profileImage;
 		this.description = description;
@@ -49,7 +47,7 @@ public class DefaultUserInfoResponse {
 	}
 
 	public static DefaultUserInfoResponse toResponse(User user, List<NotificationResponse> notifications) {
-		return new DefaultUserInfoResponse(String.valueOf(user.getId()), user.getEmail(), user.getNickname(), user.getProfileImage(),
+		return new DefaultUserInfoResponse(String.valueOf(user.getId()), user.getNickname(), user.getProfileImage(),
 			user.getDescription(), user.getRole(), user.getProficiency(), user.getPositions(), notifications,
 			user.getCreatedAt(), user.getUpdatedAt());
 	}

--- a/src/main/java/org/slams/server/user/dto/response/MyProfileLookUpResponse.java
+++ b/src/main/java/org/slams/server/user/dto/response/MyProfileLookUpResponse.java
@@ -19,7 +19,6 @@ import java.util.List;
 public class MyProfileLookUpResponse {
 
 	private String id;
-	private String email;
 	private String nickname;
 	private String profileImage;
 	private String description;
@@ -31,12 +30,11 @@ public class MyProfileLookUpResponse {
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 
-	private MyProfileLookUpResponse(String id, String email, String nickname, String profileImage,
+	private MyProfileLookUpResponse(String id, String nickname, String profileImage,
 								   String description, Role role, Proficiency proficiency, List<Position> positions,
 								   Long followerCount, Long followingCount,
 								   LocalDateTime createdAt, LocalDateTime updatedAt) {
 		this.id = id;
-		this.email = email;
 		this.nickname = nickname;
 		this.profileImage = profileImage;
 		this.description = description;
@@ -50,7 +48,7 @@ public class MyProfileLookUpResponse {
 	}
 
 	public static MyProfileLookUpResponse toResponse(User user, Long followerCount, Long followingCount) {
-		return new MyProfileLookUpResponse(String.valueOf(user.getId()), user.getEmail(), user.getNickname(), user.getProfileImage(),
+		return new MyProfileLookUpResponse(String.valueOf(user.getId()), user.getNickname(), user.getProfileImage(),
 			user.getDescription(), user.getRole(), user.getProficiency(), user.getPositions(), followerCount, followingCount,
 			user.getCreatedAt(), user.getUpdatedAt());
 	}

--- a/src/main/java/org/slams/server/user/entity/User.java
+++ b/src/main/java/org/slams/server/user/entity/User.java
@@ -32,7 +32,7 @@ public class User extends BaseEntity {
 	private String socialId;
 
 	@Pattern(regexp = "\\b[\\w\\.-]+@[\\w\\.-]+\\.\\w{2,4}\\b")
-	@Column(name = "email", nullable = false, length = 50, unique = true)
+	@Column(name = "email", length = 50, unique = true)
 	private String email;
 
 	@Column(name = "nickname", nullable = false, length = MAX_NICKNAME_LENGTH)
@@ -58,7 +58,6 @@ public class User extends BaseEntity {
 	private User(String socialId, String email, String nickname, String profileImage,
 				 String description, Role role, Proficiency proficiency, List<Position> positions) {
 		Assert.notNull(socialId, "socialId는 null이 될 수 없습니다.");
-		Assert.notNull(email, "email은 null이 될 수 없습니다.");
 		Assert.notNull(role, "role은 null이 될 수 없습니다.");
 
 		validateNickname(nickname);

--- a/src/main/java/org/slams/server/user/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/org/slams/server/user/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -70,7 +70,7 @@ public class OAuth2AuthenticationSuccessHandler extends SavedRequestAwareAuthent
 	}
 
 	private String generateToken(User user) {
-		return jwt.sign(Jwt.Claims.from(user.getId(), user.getEmail(), new String[]{user.getRole().toString()}));
+		return jwt.sign(Jwt.Claims.from(user.getId(), new String[]{user.getRole().toString()}));
 	}
 
 }

--- a/src/main/java/org/slams/server/user/oauth/jwt/Jwt.java
+++ b/src/main/java/org/slams/server/user/oauth/jwt/Jwt.java
@@ -58,7 +58,6 @@ public class Jwt {
 	@Getter
 	public static class Claims {
 		Long userId;
-		String email;
 		String[] roles;
 		Date iat; // token 발행일자
 		Date exp; // token 만료일자
@@ -71,11 +70,6 @@ public class Jwt {
 				this.userId = userId.asLong();
 			}
 
-			Claim email = decodedJWT.getClaim("email");
-			if(!email.isNull()){
-				this.email = email.asString();
-			}
-
 			Claim roles = decodedJWT.getClaim("roles");
 			if (!roles.isNull()) {
 				this.roles = roles.asArray(String.class);
@@ -85,22 +79,11 @@ public class Jwt {
 			this.exp = decodedJWT.getExpiresAt();
 		}
 
-		public static Claims from(Long userId, String email, String[] roles) {
+		public static Claims from(Long userId, String[] roles) {
 			Claims claims = new Claims();
 			claims.userId = userId;
-			claims.email = email;
 			claims.roles = roles;
 			return claims;
-		}
-
-		public Map<String, Object> asMap() {
-			Map<String, Object> map = new HashMap<>();
-			map.put("userId", userId);
-			map.put("email", email);
-			map.put("roles", roles);
-			map.put("iat", iat());
-			map.put("exp", exp());
-			return map;
 		}
 
 		public long iat() {
@@ -115,7 +98,6 @@ public class Jwt {
 		public String toString() {
 			return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
 				.append("userId", userId)
-				.append("email", email)
 				.append("roles", Arrays.toString(roles))
 				.append("iat", iat)
 				.append("exp", exp)

--- a/src/main/java/org/slams/server/user/service/OAuthUserService.java
+++ b/src/main/java/org/slams/server/user/service/OAuthUserService.java
@@ -59,7 +59,7 @@ public class OAuthUserService {
 				Map<String, Object> accountsDetail = (Map<String, Object>) accounts.get("profile");
 
 				String nickname = (String) properties.get("nickname");
-				String email = (String) accounts.get("email");
+				String email = null; // 이메일 수집 철회
 				String profileImage = (String) accountsDetail.get("profile_image_url");
 				profileImage= "https" + profileImage.substring(4); // http -> https 변환하여 저장
 				Boolean isDefaultImage = (Boolean) accountsDetail.get("is_default_image");


### PR DESCRIPTION
**🤔💭 회원가입 시 이메일 수집 꼭 필요할까? -> NO!**
=> whitelabel 에러(이메일 제공동의를 하지 않았을 때 발생하는 에러) 발생하지 않을 것.

## ✍️ 변경사항
1. 유저 테이블의 email값의 `null` 허용
2. 회원가입시 email값에 `null`이 저장
3. 
<img width="1792" alt="스크린샷 2022-11-15 오후 5 11 54" src="https://user-images.githubusercontent.com/65434196/201874227-5b54f18d-259a-4bc1-8c09-bf62feda2f1b.png">

close #73 